### PR TITLE
feat: Jakarta EE 対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ MOM応答不要メッセージングの送信側のExampleと組み合わせて�
 
 ### 1.動作環境
 実行環境に以下のソフトウェアがインストールされている事を前提とします。
-* Java Version : 8
-* Maven 3.0.5以降
+* Java Version : 17
+* Maven 3.9.0以降
 
 補足：
 MOMとRDBMSはExampleに組み込まれたものを使用します。
@@ -65,40 +65,46 @@ Gitを使用しない場合、最新のタグからzipをダウンロードし�
 
 起動に成功すると以下のようなログがコンソールに出力され、MOM応答不要メッセージングの送信側からのメッセージの受信待ちの状態になります。
 
-    2016-06-09 09:38:04.784 -INFO- ROO [null] load environment config file. file = classpath:env.config
-     INFO | Using Persistence Adapter: MemoryPersistenceAdapter
-     INFO | Apache ActiveMQ 5.13.0 (localhost, ID:S1306C00419-T1-25411-1465432685143-0:1) is starting
-     INFO | Listening for connections at: tcp://127.0.0.1:61616
-     INFO | Connector tcp://127.0.0.1:61616 started
-     INFO | Apache ActiveMQ 5.13.0 (localhost, ID:S1306C00419-T1-25411-1465432685143-0:1) started
-     INFO | For help or more information please see: http://activemq.apache.org
-     WARN | Memory Usage for the Broker (1024 mb) is more than the maximum available for the JVM: 247 mb - resetting to 70% of maximum available: 173 mb
-     WARN | Temporary Store limit is 51200 mb (current store usage is 0 mb). The data directory: C:\Users\TIS303995\git\nablarch-example\nablarch-example-mom-delayed-receive only has 6632 mb of usable space - resetting to maximum available disk space: 6632 mb
-    2016-06-09 09:38:06.168 -INFO- ROO [null] @@@@ APPLICATION SETTINGS @@@@
+```log
+2023-02-15 14:45:13.642 -INFO- nablarch.fw.launcher.Main [null] boot_proc = [] proc_sys = [mom-delayed-recei
+ve] req_id = [null] usr_id = [null] @@@@ APPLICATION SETTINGS @@@@
         system settings = {
         }
         business date = [20140123]
+```
 
 MOM応答不要メッセージングの送信側を起動すると、MOM応答不要メッセージングの受信側のコンソールに以下のように、メッセージを受信したことと、メッセージを返信したことを示すログが出力されます。
 (コンソール中の文字が化けるのは仕様です。)
 
-    2016-06-09 09:58:42.405 -INFO- ROO [201606090958063480006] @@@@ RECEIVED MESSAGE @@@@
-            thread_name    = [pool-1-thread-1]
-            message_id     = [ID:S1306C00419-T1-20683-1465433922061-1:1:1:1:1]
-            destination    = [TEST.REQUEST]
-            correlation_id = [null]
-            reply_to       = [null]
-            message_body   = [ProjectInsertMessage0000000001100                 ?v???W?F?N?g?O?O?P
-                                                                                                    development
-                                                                                                                        s
-                                                                                                                                            20100918201504091        ????
-                                                                                                                                                                                         ????
-                                                                                                                                                                                                             100      ???l??
+```log
+2023-02-15 14:46:39.456 -INFO- MESSAGING [202302151445136440001] boot_proc = [] proc_sys = [mom-delayed-receive] req_
+id = [RECEIVEAPP] usr_id = [batch_user] @@@@ RECEIVED MESSAGE @@@@
+        thread_name    = [pool-1-thread-1]
+        message_id     = [ID:1e07ab35-acf4-11ed-8482-9c7befbbf589]
+        destination    = [TEST.REQUEST]
+        correlation_id = [null]
+        reply_to       = [null]
+        message_body   = [ProjectInsertMessage0000000001                    ?v???W?F?N?g?O?O?P
+
+                                                                                                  development
+                                                                                                             s
+
+   20100918201504091        ????
+
+                                                  ????
+
+                                                                        100      ???l??
 
 
 
 
-                                                          10000    1000     2000     3000           ]
+
+
+
+
+                                                    10000    1000     2000     3000       ]
+```
+
 
 自動的に終了はしないため、ctrl + c等で終了させてください。
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,14 +8,16 @@
   <packaging>jar</packaging>
 
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <db.adminUser>SAMPLE</db.adminUser>
     <db.user>SAMPLE</db.user>
+
+    <activemq.version>2.28.0</activemq.version>
   </properties>
 
   <profiles>
@@ -123,9 +125,14 @@
     </dependency>
 
     <dependency>
-        <groupId>org.apache.activemq</groupId>
-        <artifactId>activemq-all</artifactId>
-        <version>5.13.0</version>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>artemis-server</artifactId>
+      <version>${activemq.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>artemis-jakarta-server</artifactId>
+      <version>${activemq.version}</version>
     </dependency>
     <!-- MOMメッセージング用に追加したライブラリここまで============================= -->
 
@@ -153,7 +160,7 @@
       <plugin>
         <groupId>jp.co.tis.gsp</groupId>
         <artifactId>gsp-dba-maven-plugin</artifactId>
-        <version>4.6.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <configuration>
           <adminUser>${db.adminUser}</adminUser>
           <adminPassword>${db.adminUser}</adminPassword>
@@ -185,7 +192,6 @@
             <goals>
               <goal>generate-ddl</goal>
               <goal>execute-ddl</goal>
-              <goal>generate-entity</goal>
               <goal>load-data</goal>
             </goals>
           </execution>


### PR DESCRIPTION
ActiveMQ を Artemis に変えたことでログが変わったのと、そもそもフォーマットが古い状態だったのでログの出力例を新しく置き換えました。

generate-entity は、生成されたエンティティを使用していないので削除しました。
残っていると jvm.config を置く必要が発生するので。