### PR TITLE
docs: READMEのH2データベースファイル名をSAMPLE.mv.dbに修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ id = [RECEIVEAPP] usr_id = [batch_user] @@@@ RECEIVED MESSAGE @@@@
   ※h2.bat実行中はExampleアプリケーションからDBへアクセスすることができないため、Exampleアプリケーションを停止しておいてください。
 
 3. ブラウザから http://localhost:8082 を開き、以下の情報でH2コンソールにログインしてください。
-   JDBC URLの{dbファイルのパス}には、`SAMPLE.h2.db`ファイルの格納ディレクトリまでのパスを指定してください。  
+   JDBC URLの{dbファイルのパス}には、`SAMPLE.mv.db`ファイルの格納ディレクトリまでのパスを指定してください。  
   JDBC URL：jdbc:h2:{dbファイルのパス}/SAMPLE  
   ユーザ名：SAMPLE  
   パスワード：SAMPLE


### PR DESCRIPTION
## 背景

READMEの「DBの確認方法」で、H2コンソール接続時に `SAMPLE.h2.db` ファイルの格納ディレクトリを探すよう案内していますが、本Exampleが同梱するH2は 2.2.220（pom.xmlで確認）であり、生成されるDBファイルはMVStore形式の `SAMPLE.mv.db` のみです。

`.h2.db`（PageStore形式）はH2 1.x系の旧形式のファイル名であり、現在の構成では生成されません。READMEの記載どおりに `SAMPLE.h2.db` を探すと該当ファイルが見つからず、利用者が手順を進められなくなります。

## 修正内容

- README.md のDBファイル名記載を `SAMPLE.h2.db` から `SAMPLE.mv.db` に修正（1箇所）

## 確認事項

- pom.xml のH2バージョンが 2.2.220 であることを確認済み
- README内の外部リンクの疎通（HTTP 200）を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)
